### PR TITLE
Fix a bug in the agent's linear layers

### DIFF
--- a/TPR_utils.py
+++ b/TPR_utils.py
@@ -21,7 +21,6 @@ class TPR(nn.Module):
         nn.init.orthogonal_(self.filler_emb.weight, gain=1)
         self.filler_emb.weight.data[0, :] = 0
         nn.init.orthogonal_(self.role_emb.weight, gain=1)
-        self.filler_emb.weight.data[0, :] = 0
 
     def forward(self, tree_tensor):
         '''

--- a/data.py
+++ b/data.py
@@ -36,7 +36,7 @@ class BinaryT2TDataset(Dataset):
 
         dataset_max_depth = 0
 
-        is_xy_file = True
+        is_xy_file = False
         for line in data:
             if is_xy_file:
                 inout_pair = line.split('\t')

--- a/data.py
+++ b/data.py
@@ -36,22 +36,10 @@ class BinaryT2TDataset(Dataset):
 
         dataset_max_depth = 0
 
-        is_xy_file = False
         for line in data:
-            if is_xy_file:
-                inout_pair = line.split('\t')
-                tt = None
-
-                if len(inout_pair) > 2:
-                    # remove 3rd field used for filtering
-                    tt = inout_pair[2].strip()
-                    inout_pair = inout_pair[0:2]
-                in_node = text_tree_to_node(inout_pair[0])
-                out_node = text_tree_to_node(inout_pair[1])
-            else:
-                inout_pair = json.loads(line)
-                in_node = text_tree_to_node(inout_pair['source'])
-                out_node = text_tree_to_node(inout_pair['target'])
+            inout_pair = json.loads(line)
+            in_node = text_tree_to_node(inout_pair['source'])
+            out_node = text_tree_to_node(inout_pair['target'])
 
             example = {"input": in_node, "output": out_node, "example_type": None}
 

--- a/data.py
+++ b/data.py
@@ -36,10 +36,22 @@ class BinaryT2TDataset(Dataset):
 
         dataset_max_depth = 0
 
+        is_xy_file = True
         for line in data:
-            inout_pair = json.loads(line)
-            in_node = text_tree_to_node(inout_pair['source'])
-            out_node = text_tree_to_node(inout_pair['target'])
+            if is_xy_file:
+                inout_pair = line.split('\t')
+                tt = None
+
+                if len(inout_pair) > 2:
+                    # remove 3rd field used for filtering
+                    tt = inout_pair[2].strip()
+                    inout_pair = inout_pair[0:2]
+                in_node = text_tree_to_node(inout_pair[0])
+                out_node = text_tree_to_node(inout_pair[1])
+            else:
+                inout_pair = json.loads(line)
+                in_node = text_tree_to_node(inout_pair['source'])
+                out_node = text_tree_to_node(inout_pair['target'])
 
             example = {"input": in_node, "output": out_node, "example_type": None}
 

--- a/models.py
+++ b/models.py
@@ -119,6 +119,10 @@ class NeuralTreeAgent(nn.Module):
                                                        dropout=dropout, activation=activation,
                                                        layer_norm_eps=layer_norm_eps,
                                                        batch_first=True, norm_first=bool(transformer_norm_first))
+
+        self.op_dist_fn = op_dist_fn
+        self.arg_dist_fn = arg_dist_fn
+
         self.layers = nn.ModuleList()
         self.arg_logits_list = nn.ModuleList()
         self.root_filler_list = nn.ModuleList()

--- a/models.py
+++ b/models.py
@@ -120,31 +120,42 @@ class NeuralTreeAgent(nn.Module):
                                                        layer_norm_eps=layer_norm_eps,
                                                        batch_first=True, norm_first=bool(transformer_norm_first))
         self.layers = nn.ModuleList()
+        self.arg_logits_list = nn.ModuleList()
+        self.root_filler_list = nn.ModuleList()
+        self.op_logits_list = nn.ModuleList()
         for i in range(steps):
             encoder_norm = nn.LayerNorm(d_model, eps=layer_norm_eps) if transformer_norm_first else None
             self.layers.append(nn.TransformerEncoder(transformer_layer, transformer_layers_per_step, encoder_norm))
 
-        # 4 for the 4 arguments, car, cdr, cons1, cons2
-        self.arg_logits = nn.Linear(d_model, 4)
-        self.root_filler = nn.Linear(d_model, d_filler)
-        self.op_logits = nn.Linear(d_model, num_ops)
-        self.op_dist_fn = op_dist_fn
-        self.arg_dist_fn = arg_dist_fn
+            # 4 for the 4 arguments, car, cdr, cons1, cons2
+            arg_logits = nn.Linear(d_model, 4)
+            nn.init.normal_(arg_logits.weight, std=0.02)
+            nn.init.zeros_(arg_logits.bias)
+            self.arg_logits_list.append(arg_logits)
+
+            root_filler = nn.Linear(d_model, d_filler)
+            self.root_filler_list.append(root_filler)
+
+            op_logits = nn.Linear(d_model, num_ops)
+            nn.init.normal_(op_logits.weight, std=0.02)
+            nn.init.zeros_(op_logits.bias)
+
+            self.op_logits_list.append(op_logits)
 
     def forward(self, encodings, step):
         # TODO: move pashamax, sparsemax, softmax from the old car/cdr/consnet to here for op_dist and arg_weights
         encodings = self.layers[step](encodings)
 
-        op_logits = self.op_logits(encodings[:, 0, :])
+        op_logits = self.op_logits_list[step](encodings[:, 0, :])
         if self.op_dist_fn == 'softmax':
             op_dist = F.softmax(op_logits, dim=-1)
         elif self.op_dist_fn == 'gumbel':
             op_dist = F.gumbel_softmax(op_logits, tau=self.gumbel_temp)
         else:
             raise ValueError('Unknown op_dist_fn: {}'.format(self.op_dist_fn))
-        root_filler = self.root_filler(encodings[:, 1, :])
+        root_filler = self.root_filler_list[step](encodings[:, 1, :])
 
-        arg_logits = self.arg_logits(encodings[:, 2:, :])
+        arg_logits = self.arg_logits_list[step](encodings[:, 2:, :])
         if self.arg_dist_fn == 'softmax':
             arg_weights = F.softmax(arg_logits, dim=1)
         elif self.arg_dist_fn == 'gumbel':

--- a/models.py
+++ b/models.py
@@ -133,17 +133,12 @@ class NeuralTreeAgent(nn.Module):
 
             # 4 for the 4 arguments, car, cdr, cons1, cons2
             arg_logits = nn.Linear(d_model, 4)
-            nn.init.normal_(arg_logits.weight, std=0.02)
-            nn.init.zeros_(arg_logits.bias)
             self.arg_logits_list.append(arg_logits)
 
             root_filler = nn.Linear(d_model, d_filler)
             self.root_filler_list.append(root_filler)
 
             op_logits = nn.Linear(d_model, num_ops)
-            nn.init.normal_(op_logits.weight, std=0.02)
-            nn.init.zeros_(op_logits.bias)
-
             self.op_logits_list.append(op_logits)
 
     def forward(self, encodings, step):


### PR DESCRIPTION
Each layer of the agent should use different linear transformations to produce the operations and argument logits, as well as the root filler.